### PR TITLE
Changed to pathname PATH_RANKING to "Ranking" from "ranking". 

### DIFF
--- a/Python/GUI_DB_Update.py
+++ b/Python/GUI_DB_Update.py
@@ -657,7 +657,7 @@ if __name__ == '__main__':
     # part). At this moment the ranking is not necessary in the DB, the web
     # already provides the result sorted by quality.
     # Same for the heteromolecules.
-                    PATH_RANKING = osp.join(NMLDB_DATA_PATH, "ranking")
+                    PATH_RANKING = osp.join(NMLDB_DATA_PATH, "Ranking",)
                     Lipid_Ranking[key] = {}
                     # Find the position of the system in the ranking
                     for file in glob.glob(osp.join(PATH_RANKING, key) + "*"):


### PR DESCRIPTION
Aimed at addressing #30.

Both seemed to work though, because it was run on MacOS with a case-insensitive file system. The import of quality metrics should work fine now. 