### PR TITLE
Show NMR metadata on experiment pages, unhide the Properties tab

### DIFF
--- a/app/Http/Controllers/ExperimentController.php
+++ b/app/Http/Controllers/ExperimentController.php
@@ -172,10 +172,11 @@ class ExperimentController extends Controller
             ->where('efl.experiment_id', $experiment->id)
             ->select('ep.name', 'ep.value', 'ep.unit', 'ep.type', 'ep.description')
             ->get();
-        // convert properties with type 'array' or 'dict' from JSON strings to PHP arrays
+        // convert properties with type 'array', 'list' or 'dict' from JSON strings to PHP arrays
+        // ('list' is what the UI_DB_Update.py importer writes for YAML sequences)
         $assocProps = [];
         foreach ($properties as $prop) {
-            if ($prop->type === 'array' || $prop->type === 'dict') {
+            if ($prop->type === 'array' || $prop->type === 'list' || $prop->type === 'dict') {
                 $prop->value = json_decode($prop->value, true);
             }
             $assocProps[$prop->name] = $prop;

--- a/app/Http/Controllers/ExperimentController.php
+++ b/app/Http/Controllers/ExperimentController.php
@@ -176,9 +176,12 @@ class ExperimentController extends Controller
         // ('list' is what the UI_DB_Update.py importer writes for YAML sequences)
         $assocProps = [];
         foreach ($properties as $prop) {
-            if ($prop->type === 'array' || $prop->type === 'list' || $prop->type === 'dict') {
-                $prop->value = json_decode($prop->value, true);
-            }
+if ($prop->type === 'array' || $prop->type === 'list' || $prop->type === 'dict') {
+    $decoded = json_decode($prop->value, true);
+    if (json_last_error() === JSON_ERROR_NONE) {
+        $prop->value = $decoded;
+    }
+}
             $assocProps[$prop->name] = $prop;
         }
         // Fetch membrane composition property if exists

--- a/config/app.php
+++ b/config/app.php
@@ -14,7 +14,7 @@ return [
     */
 
     'name' => env('APP_NAME', 'FAIRMD Lipids'),
-    'version' => '2.0.0', // Application version
+    'version' => '2.0.1', // Application version
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/experiment/show.blade.php
+++ b/resources/views/experiment/show.blade.php
@@ -1,5 +1,16 @@
 @extends('layouts.app')
 @section('content')
+    @php
+        // Properties that get their own rows in the Overview tab (or are outdated and
+        // deliberately suppressed) must not be repeated in the generic Properties tab.
+        // Computed here, before the tab bar, so the Properties tab button knows whether
+        // there is anything left to show.
+        $properties_in_overview = [
+            'TEMPERATURE', 'TOTAL_HYDRATION', 'PH', 'REAGENT_SOURCES', 'SAMPLE_PROTOCOL',
+            'TOTAL_LIPID_CONCENTRATION', 'COUNTER_IONS', 'XRAY', 'NMR',
+        ];
+        $properties_to_show = array_diff_key($properties, array_flip($properties_in_overview));
+    @endphp
     <!-- Main page -->
         <div class="container px-4 px-lg-5">
             <div class="row gx-4 gx-lg-5 justify-content-center">
@@ -17,7 +28,7 @@
                             <button class="nav-link" id="analysis-tab" data-bs-toggle="tab" data-bs-target="#analysis" type="button" role="tab">Data</button>
                         </li>
                         <li class="nav-item" role="presentation">
-                            <button class="nav-link{{ !isset($properties_to_show) || count($properties_to_show) === 0 ? ' d-none' : '' }}" id="properties-tab" data-bs-toggle="tab"  data-bs-target="#properties" type="button" role="tab">Properties</button>
+                            <button class="nav-link{{ count($properties_to_show) === 0 ? ' d-none' : '' }}" id="properties-tab" data-bs-toggle="tab"  data-bs-target="#properties" type="button" role="tab">Properties</button>
                         </li>
                         <!-- Add cross reference links to related simulations if available -->
                         @if (count($related_simulations) > 0) 
@@ -133,6 +144,17 @@
                                             <!-- tr>
                                                 <th scope="row" colspan="2">X-ray properties</th>
                                             </tr -->
+                                            @php
+                                                // Keys with a dedicated row below; anything else the README
+                                                // carries is listed generically at the end of the block so it
+                                                // does not silently disappear from the page.
+                                                $xray_labelled = [
+                                                    'DETECTOR', 'SOURCE', 'LAMBDA', 'BEAMSIZE', 'DISTANCE',
+                                                    'DATATYPE', 'EXPOSURE', 'FRAMES', 'SAMPLE_TYPE', 'QRANGE',
+                                                ];
+                                                $xray_value = is_array($properties['XRAY']->value) ? $properties['XRAY']->value : [];
+                                                $xray_extra = array_diff_key($xray_value, array_flip($xray_labelled));
+                                            @endphp
                                              <tr>
                                                 <th scope="row">X-ray detector</th>
                                                 <td>{{ $properties['XRAY']->value['DETECTOR'] ?? 'N/A' }}</td>
@@ -142,14 +164,15 @@
                                                 <td>{{ $properties['XRAY']->value['SOURCE'] ?? 'N/A' }}</td>
                                             </tr>
                                             <tr>
-                                                <th scope="row">X-ray wavelength (nm)</th>
+                                                <th scope="row">X-ray wavelength (Å)</th>
                                                 <td>{{ $properties['XRAY']->value['LAMBDA'] ?? 'N/A' }}</td>
                                             </tr>
                                             <tr>
-                                                <th scope="row">X-ray beam size (mm)</th>
+                                                <!-- BEAMSIZE is recorded with its own unit, e.g. "0.24 x 0.24 mm" -->
+                                                <th scope="row">X-ray beam size</th>
                                                 <td>{{ $properties['XRAY']->value['BEAMSIZE'] ?? 'N/A' }}</td>
                                             </tr>
-                                           
+
                                             <tr>
                                                 <th scope="row">X-ray distance to sample (m)</th>
                                                 <td>{{ $properties['XRAY']->value['DISTANCE'] ?? 'N/A' }}</td>
@@ -174,6 +197,45 @@
                                                 <th scope="row">X-ray Q-range (Å⁻¹)</th>
                                                 <td>{{ $properties['XRAY']->value['QRANGE'] ?? 'N/A' }}</td>
                                             </tr>
+                                            @foreach ($xray_extra as $key => $value)
+                                            <tr>
+                                                <th scope="row">X-ray {{ strtolower(str_replace('_', ' ', $key)) }}</th>
+                                                <td>{{ is_array($value) ? json_encode($value) : $value }}</td>
+                                            </tr>
+                                            @endforeach
+                                        @endif
+                                        @if ($properties['NMR'] ?? false)
+                                            @php
+                                                $nmr_labelled = ['METHOD', 'INSTRUMENT', 'T_RF_HEATING', 'SIGN_MEASURED', 'DETAILS'];
+                                                $nmr_value = is_array($properties['NMR']->value) ? $properties['NMR']->value : [];
+                                                $nmr_extra = array_diff_key($nmr_value, array_flip($nmr_labelled));
+                                            @endphp
+                                            <tr>
+                                                <th scope="row">NMR method</th>
+                                                <td>{{ $properties['NMR']->value['METHOD'] ?? 'N/A' }}</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row">NMR instrument</th>
+                                                <td>{{ $properties['NMR']->value['INSTRUMENT'] ?? 'N/A' }}</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row">NMR RF heating correction</th>
+                                                <td>{{ $properties['NMR']->value['T_RF_HEATING'] ?? 'N/A' }}</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row">NMR sign measured</th>
+                                                <td>{{ $properties['NMR']->value['SIGN_MEASURED'] ?? 'N/A' }}</td>
+                                            </tr>
+                                            <tr>
+                                                <th scope="row">NMR details</th>
+                                                <td>{{ $properties['NMR']->value['DETAILS'] ?? 'N/A' }}</td>
+                                            </tr>
+                                            @foreach ($nmr_extra as $key => $value)
+                                            <tr>
+                                                <th scope="row">NMR {{ strtolower(str_replace('_', ' ', $key)) }}</th>
+                                                <td>{{ is_array($value) ? json_encode($value) : $value }}</td>
+                                            </tr>
+                                            @endforeach
                                         @endif
                                         <tr>
                                             <th scope="row">Show on GitHub</th>
@@ -188,19 +250,8 @@
                                 </table>
                             </div>
                         </div>
-                        <!-- Properties Tab -->
-                        @php
-                            unset($properties['TEMPERATURE']);
-                            unset($properties['TOTAL_HYDRATION']);
-                            unset($properties['PH']);
-                            unset($properties['REAGENT_SOURCES']);
-                            unset($properties['SAMPLE_PROTOCOL']);
-                            unset($properties['TOTAL_LIPID_CONCENTRATION']);
-                            unset($properties['COUNTER_IONS']);
-                            unset($properties['XRAY']);
-                        @endphp
-                          
-                        @if (count($properties) > 0)
+                        <!-- Properties Tab: everything not already covered by the Overview tab -->
+                        @if (count($properties_to_show) > 0)
                         
                             <div class="tab-pane fade" id="properties" role="tabpanel" aria-labelledby="properties-tab">
                                 <br/>
@@ -214,12 +265,12 @@
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @foreach ($properties as $prop)
+                                        @foreach ($properties_to_show as $prop)
                                         <tr>
                                             <td>{{ $prop->name }}</td>
                                             <!--td>{{ $prop->description }}</td-->
                                             <td>
-                                            @if( preg_match('/^(array|dict)$/', $prop->type) )
+                                            @if( preg_match('/^(array|list|dict)$/', $prop->type) )
                                             <!-- Format arrays and dictionaries nicely using html in nested tables -->
                                                 @php
                                                     $decoded_value = $prop->value;

--- a/resources/views/experiment/show.blade.php
+++ b/resources/views/experiment/show.blade.php
@@ -152,8 +152,9 @@
                                                     'DETECTOR', 'SOURCE', 'LAMBDA', 'BEAMSIZE', 'DISTANCE',
                                                     'DATATYPE', 'EXPOSURE', 'FRAMES', 'SAMPLE_TYPE', 'QRANGE',
                                                 ];
-                                                $xray_value = is_array($properties['XRAY']->value) ? $properties['XRAY']->value : [];
-                                                $xray_extra = array_diff_key($xray_value, array_flip($xray_labelled));
+$xray_value = is_array($properties['XRAY']->value) ? $properties['XRAY']->value : [];
+$properties['XRAY']->value = $xray_value;
+$xray_extra = array_diff_key($xray_value, array_flip($xray_labelled));
                                             @endphp
                                              <tr>
                                                 <th scope="row">X-ray detector</th>

--- a/tests/Feature/ExperimentsTest.php
+++ b/tests/Feature/ExperimentsTest.php
@@ -29,3 +29,43 @@ test('the experiment details page returns a successful response for an FF experi
     ->assertSee('data-ffdata=')
     ;
 });
+
+test('the NMR metadata of an OP experiment is shown in the overview tab', function () {
+    $response = $this->get('experiment/OP/10.1021/acs.jpcb.4c04719/1');
+
+    $response->assertStatus(200)
+    ->assertSee('NMR method')
+    ->assertSee('PDLF:R18_1^7')
+    ->assertSee('NMR instrument')
+    ->assertSee('Bruker Avance III HD 500 MHz, Triple Resonance CP-MAS Probe (4mm)')
+    ->assertSee('NMR RF heating correction')
+    ->assertSee('NMR sign measured')
+    ->assertSee('NMR details')
+    ->assertSee('1H-13C R-PDLF with R18_1^7 recoupling and INEPT readout at 5 kHz MAS')
+    ;
+});
+
+test('the properties tab is reachable when there are properties left to show', function () {
+    // Regression test for #141: the tab button was permanently hidden because it
+    // was guarded by an undefined variable, which buried the NMR metadata with it.
+    $response = $this->get('experiment/OP/10.1021/acs.jpcb.4c04719/1');
+
+    $response->assertStatus(200)
+    ->assertDontSee('class="nav-link d-none" id="properties-tab"', escape: false)
+    ;
+});
+
+test('the X-ray metadata of an FF experiment is shown in the overview tab', function () {
+    $response = $this->get('experiment/FF/10.1016/j.chemphyslip.2020.104892/1');
+
+    $response->assertStatus(200)
+    ->assertSee('X-ray wavelength (Å)')
+    ->assertSee('X-ray beam size')
+    ->assertSee('0.24 x 0.24 mm')
+    // PIXEL_SIZE and SAMPLE_CONTAINER have no dedicated row and no schema entry,
+    // so they must fall through to the generic rows at the end of the block.
+    ->assertSee('X-ray pixel size')
+    ->assertSee('X-ray sample container')
+    ->assertSee('1 mm quartz capillary')
+    ;
+});


### PR DESCRIPTION
Fixes #141.

The NMR section of README.yaml was never missing from the database or the served HTML — it was rendered inside the Properties tab, whose button was permanently hidden. Since 851bc3c the button's visibility was guarded by $properties_to_show, a variable no controller, composer or share ever defined, so !isset() was always true and 'd-none' was always emitted. X-ray metadata appeared unaffected only because it has dedicated rows in the Overview tab; NMR had none and fell through to the unreachable tab.

- Compute $properties_to_show with array_diff_key before the tab bar, so the guard has a real value. Replaces the @php unset() block, which ran after the nav and only mutated $properties.
- Render NMR (method, instrument, RF heating correction, sign measured, details) as Overview rows, mirroring the X-ray block.
- Label X-ray wavelength in Å, not nm, per the experiment schema. Drop the hardcoded (mm) from beam size — BEAMSIZE records its own unit.
- End both the X-ray and NMR blocks with a generic loop over keys that have no dedicated row, so fields the schema does not declare (PIXEL_SIZE, SAMPLE_CONTAINER) stop disappearing from the page.
- Decode 'list'-typed properties, which UI_DB_Update.py writes for YAML sequences but the controller and view only matched as 'array'.

Adds feature tests for the NMR rows, the tab button no longer carrying 'd-none', and the X-ray rows including the fall-through fields.